### PR TITLE
Fix maxZoom

### DIFF
--- a/gtk/src/toga_gtk/widgets/mapview.py
+++ b/gtk/src/toga_gtk/widgets/mapview.py
@@ -37,7 +37,7 @@ MAPVIEW_HTML_CONTENT = """<!DOCTYPE html>
         const map = L.map("map");
         const pins = {};
         const tiles = L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
-            maxZoom: 19,
+            maxZoom: 20,
             attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
         }).addTo(map);
     </script>


### PR DESCRIPTION
The documentation says:

> and zoomed to the required level of detail using an integer from 0 (for global detail) to 20 (for building level detail)

but the HTML declares a `maxZoom` of 19.